### PR TITLE
Build fix for 4.20-rc

### DIFF
--- a/driver/src/devicedrv/mali/linux/mali_memory_block_alloc.c
+++ b/driver/src/devicedrv/mali/linux/mali_memory_block_alloc.c
@@ -301,7 +301,7 @@ void mali_mem_block_mali_unmap(mali_mem_allocation *alloc)
 
 int mali_mem_block_cpu_map(mali_mem_backend *mem_bkend, struct vm_area_struct *vma)
 {
-	int ret;
+	vm_fault_t ret;
 	mali_mem_block_mem *block_mem = &mem_bkend->block_mem;
 	unsigned long addr = vma->vm_start;
 	struct mali_page_node *m_page;
@@ -309,7 +309,7 @@ int mali_mem_block_cpu_map(mali_mem_backend *mem_bkend, struct vm_area_struct *v
 
 	list_for_each_entry(m_page, &block_mem->pfns, list) {
 		MALI_DEBUG_ASSERT(m_page->type == MALI_PAGE_NODE_BLOCK);
-		ret = vm_insert_pfn(vma, addr, _mali_page_node_get_pfn(m_page));
+		ret = vmf_insert_pfn(vma, addr, _mali_page_node_get_pfn(m_page));
 
 		if (unlikely(0 != ret)) {
 			return -EFAULT;

--- a/driver/src/devicedrv/mali/linux/mali_memory_cow.c
+++ b/driver/src/devicedrv/mali/linux/mali_memory_cow.c
@@ -523,7 +523,7 @@ int mali_mem_cow_cpu_map(mali_mem_backend *mem_bkend, struct vm_area_struct *vma
 {
 	mali_mem_cow *cow = &mem_bkend->cow_mem;
 	struct mali_page_node *m_page;
-	int ret;
+	vm_fault_t ret;
 	unsigned long addr = vma->vm_start;
 	MALI_DEBUG_ASSERT(mem_bkend->type == MALI_MEM_COW);
 
@@ -532,7 +532,7 @@ int mali_mem_cow_cpu_map(mali_mem_backend *mem_bkend, struct vm_area_struct *vma
 		 * flush which makes it way slower than remap_pfn_range or vm_insert_pfn.
 		ret = vm_insert_page(vma, addr, page);
 		*/
-		ret = vm_insert_pfn(vma, addr, _mali_page_node_get_pfn(m_page));
+		ret = vmf_insert_pfn(vma, addr, _mali_page_node_get_pfn(m_page));
 
 		if (unlikely(0 != ret)) {
 			return ret;
@@ -557,7 +557,7 @@ _mali_osk_errcode_t mali_mem_cow_cpu_map_pages_locked(mali_mem_backend *mem_bken
 {
 	mali_mem_cow *cow = &mem_bkend->cow_mem;
 	struct mali_page_node *m_page;
-	int ret;
+	vm_fault_t ret;
 	int offset;
 	int count ;
 	unsigned long vstart = vma->vm_start;
@@ -569,7 +569,7 @@ _mali_osk_errcode_t mali_mem_cow_cpu_map_pages_locked(mali_mem_backend *mem_bken
 
 	list_for_each_entry(m_page, &cow->pages, list) {
 		if ((count >= offset) && (count < offset + num)) {
-			ret = vm_insert_pfn(vma, vaddr, _mali_page_node_get_pfn(m_page));
+			ret = vmf_insert_pfn(vma, vaddr, _mali_page_node_get_pfn(m_page));
 
 			if (unlikely(0 != ret)) {
 				if (count == offset) {

--- a/driver/src/devicedrv/mali/linux/mali_memory_os_alloc.c
+++ b/driver/src/devicedrv/mali/linux/mali_memory_os_alloc.c
@@ -368,7 +368,7 @@ int mali_mem_os_cpu_map(mali_mem_backend *mem_bkend, struct vm_area_struct *vma)
 	mali_mem_os_mem *os_mem = &mem_bkend->os_mem;
 	struct mali_page_node *m_page;
 	struct page *page;
-	int ret;
+	vm_fault_t ret;
 	unsigned long addr = vma->vm_start;
 	MALI_DEBUG_ASSERT(MALI_MEM_OS == mem_bkend->type);
 
@@ -378,7 +378,7 @@ int mali_mem_os_cpu_map(mali_mem_backend *mem_bkend, struct vm_area_struct *vma)
 		ret = vm_insert_page(vma, addr, page);
 		*/
 		page = m_page->page;
-		ret = vm_insert_pfn(vma, addr, page_to_pfn(page));
+		ret = vmf_insert_pfn(vma, addr, page_to_pfn(page));
 
 		if (unlikely(0 != ret)) {
 			return -EFAULT;
@@ -393,7 +393,7 @@ _mali_osk_errcode_t mali_mem_os_resize_cpu_map_locked(mali_mem_backend *mem_bken
 {
 	mali_mem_os_mem *os_mem = &mem_bkend->os_mem;
 	struct mali_page_node *m_page;
-	int ret;
+	vm_fault_t ret;
 	int offset;
 	int mapping_page_num;
 	int count ;
@@ -416,7 +416,7 @@ _mali_osk_errcode_t mali_mem_os_resize_cpu_map_locked(mali_mem_backend *mem_bken
 
 			vm_end -= _MALI_OSK_MALI_PAGE_SIZE;
 			if (mapping_page_num > 0) {
-				ret = vm_insert_pfn(vma, vm_end, page_to_pfn(m_page->page));
+				ret = vmf_insert_pfn(vma, vm_end, page_to_pfn(m_page->page));
 
 				if (unlikely(0 != ret)) {
 					/*will return -EBUSY If the page has already been mapped into table, but it's OK*/
@@ -439,7 +439,7 @@ _mali_osk_errcode_t mali_mem_os_resize_cpu_map_locked(mali_mem_backend *mem_bken
 		list_for_each_entry(m_page, &os_mem->pages, list) {
 			if (count >= offset) {
 
-				ret = vm_insert_pfn(vma, vstart, page_to_pfn(m_page->page));
+				ret = vmf_insert_pfn(vma, vstart, page_to_pfn(m_page->page));
 
 				if (unlikely(0 != ret)) {
 					/*will return -EBUSY If the page has already been mapped into table, but it's OK*/

--- a/driver/src/devicedrv/mali/linux/mali_memory_secure.c
+++ b/driver/src/devicedrv/mali/linux/mali_memory_secure.c
@@ -110,7 +110,7 @@ void mali_mem_secure_mali_unmap(mali_mem_allocation *alloc)
 int mali_mem_secure_cpu_map(mali_mem_backend *mem_bkend, struct vm_area_struct *vma)
 {
 
-	int ret = 0;
+	vm_fault_t ret = 0;
 	struct scatterlist *sg;
 	mali_mem_secure *secure_mem = &mem_bkend->secure_mem;
 	unsigned long addr = vma->vm_start;
@@ -132,7 +132,7 @@ int mali_mem_secure_cpu_map(mali_mem_backend *mem_bkend, struct vm_area_struct *
 		MALI_DEBUG_ASSERT(0 == size % _MALI_OSK_MALI_PAGE_SIZE);
 
 		for (j = 0; j < size / _MALI_OSK_MALI_PAGE_SIZE; j++) {
-			ret = vm_insert_pfn(vma, addr, PFN_DOWN(phys));
+			ret = vmf_insert_pfn(vma, addr, PFN_DOWN(phys));
 
 			if (unlikely(0 != ret)) {
 				return -EFAULT;

--- a/driver/src/devicedrv/mali/linux/mali_memory_types.h
+++ b/driver/src/devicedrv/mali/linux/mali_memory_types.h
@@ -13,6 +13,19 @@
 
 #include <linux/mm.h>
 
+/* vm_fault_t was introduced in 4.17, and is typedef int as of 4.20 */
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,17,0))
+typedef int vm_fault_t;
+#endif
+
+/*
+ * vm_insert_pfn() was removed in 4.20. The new vmf_insert_pfn returns
+ * vm_fault_t, which is non-zero on error.
+ */
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,20,0))
+#define vmf_insert_pfn vm_insert_pfn
+#endif
+
 #if defined(CONFIG_MALI400_UMP)
 #include "ump_kernel_interface.h"
 #endif

--- a/driver/src/devicedrv/mali/linux/mali_osk_misc.c
+++ b/driver/src/devicedrv/mali/linux/mali_osk_misc.c
@@ -44,9 +44,7 @@ u32 _mali_osk_snprintf(char *buf, u32 size, const char *fmt, ...)
 
 void _mali_osk_abort(void)
 {
-	/* make a simple fault by dereferencing a NULL pointer */
-	dump_stack();
-	*(int *)0 = 0;
+	WARN_ON(1);
 }
 
 void _mali_osk_break(void)

--- a/driver/src/devicedrv/mali/linux/mali_osk_time.c
+++ b/driver/src/devicedrv/mali/linux/mali_osk_time.c
@@ -15,6 +15,7 @@
 
 #include "mali_osk.h"
 #include <linux/jiffies.h>
+#include <linux/ktime.h>
 #include <linux/time.h>
 #include <asm/delay.h>
 
@@ -46,14 +47,22 @@ void _mali_osk_time_ubusydelay(u32 usecs)
 
 u64 _mali_osk_time_get_ns(void)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,20,0))
+	return ktime_get_real_ns();
+#else
 	struct timespec tsval;
 	getnstimeofday(&tsval);
 	return (u64)timespec_to_ns(&tsval);
+#endif
 }
 
 u64 _mali_osk_boot_time_get_ns(void)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,20,0))
+	return ktime_get_boot_ns();
+#else
 	struct timespec tsval;
 	get_monotonic_boottime(&tsval);
 	return (u64)timespec_to_ns(&tsval);
+#endif
 }


### PR DESCRIPTION
Build fix for 4.20-rc, where a few APIs disappeared.

The other patch makes the GPU task aborts play nicer with the kernel.