### PR TITLE
v5.3-rc build fix

### DIFF
--- a/driver/src/devicedrv/mali/linux/mali_osk_time.c
+++ b/driver/src/devicedrv/mali/linux/mali_osk_time.c
@@ -53,7 +53,9 @@ u64 _mali_osk_time_get_ns(void)
 
 u64 _mali_osk_boot_time_get_ns(void)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 3, 0)
+	return ktime_get_boottime_ns();
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
 	return ktime_get_boot_ns();
 #else
 	struct timespec tsval;


### PR DESCRIPTION
ktime_get_boot_ns() was renamed to ktime_get_boottime_ns() in commit
9285ec4c8b61 ("timekeeping: Use proper clock specifier names in functions")
which was introduced in v5.3-rc1.

Handle this rename with yet another #if LINUX_VERSION_CODE.

Signed-off-by: Chen-Yu Tsai <wens@csie.org>